### PR TITLE
:bug: Fix undefined values being set on LearningOutcome - 4.0.0-rc.1.1

### DIFF
--- a/lib/learning-outcome/learning-outcome.ts
+++ b/lib/learning-outcome/learning-outcome.ts
@@ -164,18 +164,31 @@ export class LearningOutcome {
    * @memberof LearningOutcome
    */
   constructor(outcome?: Partial<LearningOutcome>) {
-    this.bloom = outcome ? <string>outcome.bloom : Array.from(levels)[0];
-    this.verb = outcome
-      ? <string>outcome.verb
-      : Array.from(verbs[this.bloom])[0];
-    this.text = outcome ? <string>outcome.text : '';
+    this.bloom = Array.from(levels)[0];
+    this.verb = Array.from(verbs[this.bloom])[0];
+    this.text = '';
     this._mappings = [];
-    // Add mappings from passed outcome
-    if (outcome) {
-      (<StandardOutcome[]>outcome.mappings).map(outcome => this.mapTo(outcome));
-    }
     this._assessments = [];
     this._strategies = [];
+    if (outcome) {
+      this.copyOutcome(outcome);
+    }
+  }
+
+  /**
+   * Copies properties of outcome to this outcome if defined
+   *
+   * @private
+   * @param {Partial<LearningOutcome>} outcome
+   * @memberof LearningOutcome
+   */
+  private copyOutcome(outcome: Partial<LearningOutcome>): void {
+    this.bloom = outcome.bloom || this.bloom;
+    this.verb = outcome.verb || this.verb;
+    this.text = outcome.text || this.text;
+    if (outcome.mappings) {
+      (<StandardOutcome[]>outcome.mappings).map(outcome => this.mapTo(outcome));
+    }
   }
 
   public static instantiate(

--- a/lib/learning-outcome/learning-outcome.ts
+++ b/lib/learning-outcome/learning-outcome.ts
@@ -164,9 +164,9 @@ export class LearningOutcome {
    * @memberof LearningOutcome
    */
   constructor(outcome?: Partial<LearningOutcome>) {
-    this.bloom = Array.from(levels)[0];
-    this.verb = Array.from(verbs[this.bloom])[0];
-    this.text = '';
+    this._bloom = Array.from(levels)[0];
+    this._verb = Array.from(verbs[this.bloom])[0];
+    this._text = '';
     this._mappings = [];
     this._assessments = [];
     this._strategies = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyber4all/clark-entity",
-  "version": "4.0.0-rc.1.0",
+  "version": "4.0.0-rc.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyber4all/clark-entity",
-  "version": "4.0.0-rc.1.0",
+  "version": "4.0.0-rc.1.1",
   "description": "CLARK Entities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
**Issue**
The constructor for `LearningOutcome` would error out when `outcome` existed, but some properties that should be defined were undefined.
**Solution**
Initialized default values and abstracted outcome copy to the `copyOutcome` function.