### PR TITLE
:sparkles: Add email validation function - 4.0.0-rc.6.0

### DIFF
--- a/lib/user/error-messages.ts
+++ b/lib/user/error-messages.ts
@@ -1,0 +1,5 @@
+export const USER_ERRORS = {
+  INVALID_EMAIL(email: any) {
+    return `${email} is not a valid email`;
+  }
+};

--- a/lib/user/user.spec.ts
+++ b/lib/user/user.spec.ts
@@ -1,0 +1,45 @@
+import { User } from './user';
+import { USER_ERRORS } from './error-messages';
+
+// Defaults
+
+// Valid values
+const validUsername = 'itsMe123';
+const validName = 'Itis Me';
+const validEmail = 'it@me.com';
+const validOrganization = 'My Organization';
+const validBio = 'All about me';
+
+// Invalid values
+const invalidEmail = 'not a valid email';
+
+describe('Class: User', () => {
+  let user: User;
+  beforeEach(() => {
+    user = new User();
+  });
+
+  it('should return a new blank User', () => {
+    expect(user).toBeDefined();
+  });
+  it('should return a new User with valid properties', () => {
+    const someUser: Partial<User> = {
+      username: validUsername,
+      name: validName,
+      email: validEmail,
+      organization: validOrganization,
+      bio: validBio
+    };
+    const newUser = new User(someUser);
+    expect(newUser).toBeDefined();
+  });
+  it('should set invalid email and thrown an error', () => {
+    const errorMessage = USER_ERRORS.INVALID_EMAIL(invalidEmail);
+    try {
+      user.email = invalidEmail;
+      fail(new Error(`Expected ${errorMessage}`));
+    } catch (e) {
+      expect(e.message).toEqual(errorMessage);
+    }
+  });
+});

--- a/lib/user/user.ts
+++ b/lib/user/user.ts
@@ -32,7 +32,7 @@ export class User {
     return this._email;
   }
   set email(email: string) {
-    if (email) {
+    if (email && User.isValidEmail(email)) {
       this._email = email;
     }
   }
@@ -118,5 +118,23 @@ export class User {
     this.organization = user.organization || this.organization;
     this.bio = user.bio || this.bio;
     this._createdAt = user.createdAt || this.createdAt;
+  }
+}
+
+export namespace User {
+  /**
+   * Checks email provided again email regex pattern
+   *
+   * @export
+   * @param {string} email
+   * @returns {boolean}
+   */
+  export function isValidEmail(email: string): boolean {
+    // tslint:disable-next-line:max-line-length
+    const emailPattern = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    if (emailPattern.test(email)) {
+      return true;
+    }
+    return false;
   }
 }

--- a/lib/user/user.ts
+++ b/lib/user/user.ts
@@ -1,3 +1,5 @@
+import { USER_ERRORS } from './error-messages';
+
 /**
  * A class to represent CLARK users.
  * @class
@@ -34,6 +36,8 @@ export class User {
   set email(email: string) {
     if (email && User.isValidEmail(email)) {
       this._email = email;
+    } else {
+      throw new Error(USER_ERRORS.INVALID_EMAIL(email));
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyber4all/clark-entity",
-  "version": "4.0.0-rc.5.0",
+  "version": "4.0.0-rc.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyber4all/clark-entity",
-  "version": "4.0.0-rc.5.0",
+  "version": "4.0.0-rc.6.0",
   "description": "CLARK Entities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
**Issue**
Code for email validation is often repeated across the CLARK system.

**Solution**
Create `isValidEmail` function within `User` to be used as standard  validation function.