### PR TITLE
:sparkles: Add function to convert entities to plain Js objects & :bug: Fix property setters throwing error

### DIFF
--- a/lib/learning-object/learning-object.ts
+++ b/lib/learning-object/learning-object.ts
@@ -478,8 +478,12 @@ export class LearningObject {
       this.id = object.id;
     }
     this._author = <User>object.author || this.author;
-    this.name = <string>object.name || this.name;
-    this.description = <string>object.description || this.description;
+    if (object.name) {
+      this.name = object.name;
+    }
+    if (object.description) {
+      this.description = object.description;
+    }
     this._date = <string>object.date || this.date;
     this.length = <LearningObject.Length>object.length || this.length;
     if (object.levels) {

--- a/lib/learning-object/learning-object.ts
+++ b/lib/learning-object/learning-object.ts
@@ -508,6 +508,40 @@ export class LearningObject {
     this._published = <boolean>object.published || this.published;
     this.lock = <LearningObject.Lock>object.lock || this.lock;
   }
+
+  /**
+   * Converts LearningObject to plain object without functions and private properties
+   *
+   * @returns {Partial<LearningObject>}
+   * @memberof LearningObject
+   */
+  public toPlainObject(): Partial<LearningObject> {
+    const object: Partial<LearningObject> = {
+      id: this.id,
+      author: this.author.toPlainObject() as User,
+      name: this.name,
+      description: this.description,
+      date: this.date,
+      length: this.length,
+      levels: this.levels,
+      outcomes: this.outcomes.map(
+        outcome => outcome.toPlainObject() as LearningOutcome
+      ),
+      materials: this.materials,
+      contributors: this.contributors.map(
+        contributor => contributor.toPlainObject() as User
+      ),
+      children: this.children.map(
+        child => child.toPlainObject() as LearningObject
+      ),
+      collection: this.collection,
+      status: this.status,
+      metrics: this.metrics,
+      published: this.published,
+      lock: this.lock
+    };
+    return object;
+  }
 }
 
 export namespace LearningObject {

--- a/lib/learning-outcome/learning-outcome.ts
+++ b/lib/learning-outcome/learning-outcome.ts
@@ -136,4 +136,22 @@ export class LearningOutcome {
       (<StandardOutcome[]>outcome.mappings).map(outcome => this.mapTo(outcome));
     }
   }
+  /**
+   * Converts LearningOutcome to plain object without functions and private properties
+   *
+   * @returns {Partial<LearningOutcome>}
+   * @memberof LearningOutcome
+   */
+  public toPlainObject(): Partial<LearningOutcome> {
+    const outcome: Partial<LearningOutcome> = {
+      id: this.id,
+      bloom: this.bloom,
+      verb: this.verb,
+      text: this.text,
+      mappings: this.mappings.map(
+        mapping => mapping.toPlainObject() as StandardOutcome
+      )
+    };
+    return outcome;
+  }
 }

--- a/lib/standard-outcome/standard-outcome.ts
+++ b/lib/standard-outcome/standard-outcome.ts
@@ -120,4 +120,21 @@ export class StandardOutcome implements Outcome {
       this.outcome = outcome.outcome;
     }
   }
+
+  /**
+   * Converts StandardOutcome to plain object without functions and private properties
+   *
+   * @returns {Partial<StandardOutcome>}
+   * @memberof StandardOutcome
+   */
+  public toPlainObject(): Partial<StandardOutcome> {
+    const outcome: Partial<StandardOutcome> = {
+      id: this.id,
+      author: this.author,
+      name: this.name,
+      date: this.date,
+      outcome: this.outcome
+    };
+    return outcome;
+  }
 }

--- a/lib/user/user.ts
+++ b/lib/user/user.ts
@@ -162,6 +162,26 @@ export class User {
     this.bio = user.bio || this.bio;
     this._createdAt = user.createdAt || this.createdAt;
   }
+
+  /**
+   * Converts User to plain object without functions and private properties
+   *
+   * @returns {Partial<User>}
+   * @memberof User
+   */
+  public toPlainObject(): Partial<User> {
+    const user: Partial<User> = {
+      id: this.id,
+      username: this.username,
+      name: this.name,
+      email: this.email,
+      emailVerified: this.emailVerified,
+      organization: this.organization,
+      bio: this.bio,
+      createdAt: this.createdAt
+    };
+    return user;
+  }
 }
 
 export namespace User {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyber4all/clark-entity",
-  "version": "4.0.0-rc.8.2",
+  "version": "4.0.0-rc.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyber4all/clark-entity",
-  "version": "4.0.0-rc.8.2",
+  "version": "4.0.0-rc.9.0",
   "description": "CLARK Entities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
**Issue 1**
Entities send over http would be sent with underscored properties.

**Issue 2**
`LearningObject` would throw an error if object was provided and name was not provided.

**Solution 1**
The `toPlainObject` function converts  entites to a plain javascript object to be sent via http.

**Solution 2**
Add conditionals to check if property is defined before attempting to use validation